### PR TITLE
Migrate production deploy path to Fly and Cloudflare

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.next
+.vercel
+node_modules
+coverage
+tmp
+*.zip
+*.qfx
+*.har
+Trace-*.json.gz
+Screenshot_*.png
+tsconfig.tsbuildinfo
+web.archive.org
+.env
+.env.local

--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,23 @@
 # Drizzle
 DATABASE_URL="postgresql://postgres:password@localhost:5432/le-bambou-next"
 EMAIL_PASSWORD_DEV="password"
-EMAIL_PASSWORD_PROD="password"
+
+# Production email
+RESEND_API_KEY="re_xxxxxxxxx"
+EMAIL_FROM="Le Bambou Gorilla Lodge <noreply@lebambougorillalodge.com>"
+EMAIL_TO="info@lebambougorillalodge.com"
+
+# Public deployment URLs
+NEXT_PUBLIC_SITE_URL="https://lebambougorillalodge.com"
+NEXT_PUBLIC_GALLERY_BASE_URL="https://assets.lebambougorillalodge.com"
+
+# Gallery migration to Cloudflare R2
+GALLERY_SOURCE_BASE_URL="https://old-gallery-source.example.com"
+R2_ACCOUNT_ID="account_id"
+R2_ACCESS_KEY_ID="access_key"
+R2_SECRET_ACCESS_KEY="secret_key"
+R2_UPLOAD_MODE="s3"
+R2_BUCKET="le-bambou-gallery"
 
 # Example:
 # SERVERVAR="foo"

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,0 +1,26 @@
+name: Deploy to Fly
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    concurrency:
+      group: fly-production
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy
+        run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -21,6 +21,6 @@ jobs:
         uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy
-        run: flyctl deploy --remote-only
+        run: flyctl deploy --remote-only --ha=false
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+FROM node:22-slim AS base
+
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+
+RUN corepack enable
+
+WORKDIR /app
+
+FROM base AS deps
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+FROM base AS builder
+ARG NEXT_PUBLIC_SITE_URL="https://lebambougorillalodge.com"
+ARG NEXT_PUBLIC_GALLERY_BASE_URL=""
+ENV NEXT_PUBLIC_SITE_URL=$NEXT_PUBLIC_SITE_URL
+ENV NEXT_PUBLIC_GALLERY_BASE_URL=$NEXT_PUBLIC_GALLERY_BASE_URL
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN SKIP_ENV_VALIDATION=1 pnpm build
+
+FROM node:22-slim AS runner
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV NEXT_PUBLIC_SITE_URL="https://lebambougorillalodge.com"
+ENV PORT=3000
+
+WORKDIR /app
+
+RUN groupadd --system --gid 1001 nodejs \
+  && useradd --system --uid 1001 --gid nodejs nextjs
+
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -33,13 +33,45 @@ pnpm dev
 
 ## Deployment
 
-Pre-configured for:
+The production migration target is Fly.io for the Next.js app, Neon for
+Postgres, Resend for transactional email, and Cloudflare R2 for gallery assets.
 
-- [Vercel](https://create.t3.gg/en/deployment/vercel)
-- [Netlify](https://create.t3.gg/en/deployment/netlify)
+Required Fly secrets:
 
-- 
-- [Docker](https://create.t3.gg/en/deployment/docker)
+```bash
+fly secrets set \
+  DATABASE_URL="postgres://..." \
+  RESEND_API_KEY="re_..." \
+  EMAIL_FROM="Le Bambou Gorilla Lodge <noreply@lebambougorillalodge.com>" \
+  EMAIL_TO="info@lebambougorillalodge.com"
+```
+
+Gallery assets are uploaded to R2 with:
+
+```bash
+GALLERY_SOURCE_BASE_URL="https://current-gallery-source.example.com" \
+R2_ACCOUNT_ID="..." \
+R2_ACCESS_KEY_ID="..." \
+R2_SECRET_ACCESS_KEY="..." \
+R2_BUCKET="le-bambou-gallery" \
+pnpm gallery:variants
+```
+
+If Wrangler is already logged in locally, the same migration can run without
+R2 S3 keys:
+
+```bash
+GALLERY_SOURCE_BASE_URL="https://current-gallery-source.example.com" \
+R2_UPLOAD_MODE="wrangler" \
+R2_BUCKET="le-bambou-gallery" \
+pnpm gallery:variants
+```
+
+Deploy with:
+
+```bash
+fly deploy
+```
 
 ---
 

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,25 @@
+app = "le-bambou-next"
+primary_region = "ams"
+
+[build]
+  dockerfile = "Dockerfile"
+  [build.args]
+    NEXT_PUBLIC_SITE_URL = "https://lebambougorillalodge.com"
+    NEXT_PUBLIC_GALLERY_BASE_URL = "https://assets.lebambougorillalodge.com"
+
+[env]
+  NEXT_PUBLIC_SITE_URL = "https://lebambougorillalodge.com"
+  NEXT_PUBLIC_GALLERY_BASE_URL = "https://assets.lebambougorillalodge.com"
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = false
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+
+[[vm]]
+  memory = "512mb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/fly.toml
+++ b/fly.toml
@@ -1,5 +1,5 @@
 app = "le-bambou-next"
-primary_region = "ams"
+primary_region = "lhr"
 
 [build]
   dockerfile = "Dockerfile"

--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,7 @@ await import("./src/env.js");
 
 /** @type {import("next").NextConfig} */
 const config = {
+  output: "standalone",
   allowedDevOrigins: [
     'workspace-kg.tail89034.ts.net'
   ],
@@ -17,6 +18,8 @@ const config = {
     remotePatterns: [
       { protocol: 'https', hostname: '**.vercel-storage.com' },
       { protocol: 'https', hostname: 'blob.vercel-storage.com' },
+      { protocol: 'https', hostname: 'assets.lebambougorillalodge.com' },
+      { protocol: 'https', hostname: '**.r2.dev' },
     ],
   },
   async redirects() {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1053.0",
     "@datadog/browser-rum": "^6.31.0",
     "@next/third-parties": "^15.5.14",
     "@t3-oss/env-nextjs": "^0.13.11",
@@ -23,9 +24,6 @@
     "@trpc/react-query": "^11.15.0",
     "@trpc/server": "^11.15.0",
     "@types/validator": "^13.15.10",
-    "@vercel/analytics": "^2.0.1",
-    "@vercel/blob": "^2.3.1",
-    "@vercel/speed-insights": "^2.0.0",
     "drizzle-orm": "^0.45.1",
     "framer-motion": "^12.38.0",
     "geist": "^1.7.0",
@@ -35,6 +33,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-masonry-css": "^1.0.16",
+    "resend": "^6.12.3",
     "server-only": "^0.0.1",
     "superjson": "^2.2.6",
     "validator": "^13.15.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
 
   .:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1053.0
+        version: 3.1053.0
       '@datadog/browser-rum':
         specifier: ^6.31.0
         version: 6.31.0
@@ -52,15 +55,6 @@ importers:
       '@types/validator':
         specifier: ^13.15.10
         version: 13.15.10
-      '@vercel/analytics':
-        specifier: ^2.0.1
-        version: 2.0.1(next@15.5.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
-      '@vercel/blob':
-        specifier: ^2.3.1
-        version: 2.3.1
-      '@vercel/speed-insights':
-        specifier: ^2.0.0
-        version: 2.0.0(next@15.5.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.1(postgres@3.4.8)
@@ -88,6 +82,9 @@ importers:
       react-masonry-css:
         specifier: ^1.0.16
         version: 1.0.16(react@18.3.1)
+      resend:
+        specifier: ^6.12.3
+        version: 6.12.3
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
@@ -161,6 +158,125 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-s3@3.1053.0':
+    resolution: {integrity: sha512-/oGxoB6p1Nqs935Blt+v1o+anSCEf2n3RjIrcLz84i4cn2Gr+Z7JpDdUkG5+74r5ctqEPG7k/phTGbJ9fNKnHg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.13':
+    resolution: {integrity: sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/crc64-nvme@3.972.9':
+    resolution: {integrity: sha512-P+QGozmXn2mZZI7sDgk+aUm+RTI61MPSFB+Ir2vjEjEbEsE4e7hYtzrDvAUxZy9ko81h53e11+F/GYlvwDkaOQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.39':
+    resolution: {integrity: sha512-29wX9zpAvEt1vcj0psha+y6ygBHy2V/S72mp6e7q0KARLWXq+pwE/lR6qGkwknQvruh52lXvlqZIga8Hdxkucw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.41':
+    resolution: {integrity: sha512-IA3CQTjtJkb6u1H4mE4936c8OPBMa9Jggtwe8U2Mqw/vvb/tZ5Ebd0mcZcX0uKWQhOyYo/+qNIwkV5Xh+FeJJA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.43':
+    resolution: {integrity: sha512-4mzII+3mZEVXXE1xzrLQrCJL7/r62A63bA6SVzZoNL5rqCJghpf+xgGltVrIBBs0n+mOZBKrQl2tRREtvZ5l6A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.43':
+    resolution: {integrity: sha512-HG7kQCwXtbv3oBV61Ins0oNX8KKyvrMqqRkb6ZiAfQHbMuHaiNaEb2KnpKLPkNpqImSBK82UkVE/kaY6IfWikA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.44':
+    resolution: {integrity: sha512-sDaBIT0yrNNIPfvlsiTCmANm07zKju+ipWODjEXgZlsjMeIJR3LVp7RDyAOzUoAsTbDfYKDWp+i5WrFiQP6rmQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.39':
+    resolution: {integrity: sha512-2k/amBifLd75eXNwgvPw/2lKYSQ3NhvHQgkVKVjfUq13/eJ3JRtHmznuFenn74OK3sSfp4SMy1YB2w+UVXoKqA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.43':
+    resolution: {integrity: sha512-LPc3+Y4vhH1T4x6CMqwCM6hk5+SRf/Lwmgm8INm95wxTtIRHcMwQUVkDzWu4Iw/RSncxYM2BC01OrYbxOPZvyg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.43':
+    resolution: {integrity: sha512-wQtL34lUD/09VXjwAUo2T+I3aEXRDxMB3DKmTJL/Zj0Gi6sLDTrVhae1XVt01yzkquOWajI/sZW72JGDZ1ciTw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.15':
+    resolution: {integrity: sha512-O2HDANa+MrvbxpaRVQDiH3T13uAa9AkMjKyZmDygwauAmmvqZ5B0iRmKW+fuVGW6NPXuyXurFgIx69lSvmAWGA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-expect-continue@3.972.13':
+    resolution: {integrity: sha512-sHiqIFg8o2ipT7t40B89Vj0ubSUtY6OSt/+Ee/OXhHch5K4+81zP2+QX8Lkc/nJ2QSmCySxOke7TEbmX69fe2g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.21':
+    resolution: {integrity: sha512-alAu9heyiBK/OmRNXVxq8mmPTgeW2AQ6EYjRsI38kPZa1MZvt2Jh+BlGq7/GG9OVXOaEgD7DlGj/Lzfy5OmuEg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-location-constraint@3.972.11':
+    resolution: {integrity: sha512-hkfspNUP4criAH6ton6BGKgnm5dZx+7bUOy1YqlTfejDeUPAM23D81q/IX+hdlS3KUsfwGz5ADTqZWKBEUpf4A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.42':
+    resolution: {integrity: sha512-/xNqNGXv9LaxZd25L9VV4pnSOw9OdDNO4rAHamM+h3KQBSITljIH9vk3dveGga1I2j36lQd0rdG3gjNEXvtNew==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-ssec@3.972.11':
+    resolution: {integrity: sha512-7PQvGNhtveKlvVqNahqWx5yrwxP7ecwAoB1dYBf8eKwfo2tzzCbNnW+q2nO3N066ktQaB4iBQbDRWtizm+amoQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.11':
+    resolution: {integrity: sha512-nWXXJ1r/r8N2Gw1pWolRgED38/A9A8DHR2ETWIv220zh4PZHcybbR4hUVWWktmNXTRHzDJwRluapHn0rZxuoqA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.28':
+    resolution: {integrity: sha512-qs9z5LqXO/CZC2Lg9SGKpoLU8Rhi+m2pFKZqfO9pytX1clc0katqtsDNupJxFy0xT9wsZSPzM2v1y+/H/zfp5Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1052.0':
+    resolution: {integrity: sha512-QqZNB3so7UIDxZtroc85TQaLVxdZRFm0eWM1CSR2N+b06as9TOrilvrlTZuj3guYlxMs6yLOgGxnklJ5qMYtTw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.9':
+    resolution: {integrity: sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.25':
+    resolution: {integrity: sha512-GH+Kjz4nPKWKHnsiQpnhP1MJdTGIcK4rAka6tzakgjjUkVgNsmPeEbbRAf09SzS1hjGu6duGHCBsxYke0BhHjQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@datadog/browser-core@6.31.0':
     resolution: {integrity: sha512-csH3dhHVO+qFktqUmhjlZyivCsw8B3FLDlmkF+40G7JT2V/qzVGNjWHQ3pMbom726kvmXi+6OzNmXII1ScA5sQ==}
@@ -765,6 +881,9 @@ packages:
       next: '>=14.2.35'
       react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
 
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -786,6 +905,45 @@ packages:
 
   '@rushstack/eslint-patch@1.16.1':
     resolution: {integrity: sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==}
+
+  '@smithy/core@3.24.4':
+    resolution: {integrity: sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.4':
+    resolution: {integrity: sha512-vKW0MEFRU4Y3MkVZUkpJm+g9qyPGLCXhc0YLggUdSdBB4g7IaSSsCE75P9rBXyWHrXY1UYSQUl8/DwsTR7QciA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.4':
+    resolution: {integrity: sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.7.4':
+    resolution: {integrity: sha512-HIeF+1vrDGzPkkv39Hj2vlHSXHY3p958jd/8ZnePIY6+ZOsQX8coyEUKO5yQu4r0bQIVsbpotVIrXXwyycMStQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.4.4':
+    resolution: {integrity: sha512-e5UtkMvsatzBfbeBZjEOt0k0Z3BEsjTFL/n6fdO5vtBLe67tdy0dX7xw2DU7uZ3acwoHyeCqpU2Fzb7pxwHb6Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.2':
+    resolution: {integrity: sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -1046,65 +1204,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@vercel/analytics@2.0.1':
-    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
-    peerDependencies:
-      '@remix-run/react': ^2
-      '@sveltejs/kit': ^1 || ^2
-      next: '>=14.2.35'
-      nuxt: '>= 3'
-      react: ^18 || ^19 || ^19.0.0-rc
-      svelte: '>= 4'
-      vue: ^3
-      vue-router: ^4
-    peerDependenciesMeta:
-      '@remix-run/react':
-        optional: true
-      '@sveltejs/kit':
-        optional: true
-      next:
-        optional: true
-      nuxt:
-        optional: true
-      react:
-        optional: true
-      svelte:
-        optional: true
-      vue:
-        optional: true
-      vue-router:
-        optional: true
-
-  '@vercel/blob@2.3.1':
-    resolution: {integrity: sha512-6f9oWC+DbWxIgBLOdqjjn2/REpFrPDB7y5B5HA1ptYkzZaBgL6E34kWrptJvJ7teApJdbAs3I1a5A7z1y8SDHw==}
-    engines: {node: '>=20.0.0'}
-
-  '@vercel/speed-insights@2.0.0':
-    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
-    peerDependencies:
-      '@sveltejs/kit': ^1 || ^2
-      next: '>=14.2.35'
-      nuxt: '>= 3'
-      react: ^18 || ^19 || ^19.0.0-rc
-      svelte: '>= 4'
-      vue: ^3
-      vue-router: ^4
-    peerDependenciesMeta:
-      '@sveltejs/kit':
-        optional: true
-      next:
-        optional: true
-      nuxt:
-        optional: true
-      react:
-        optional: true
-      svelte:
-        optional: true
-      vue:
-        optional: true
-      vue-router:
-        optional: true
-
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1182,9 +1281,6 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
-  async-retry@1.3.3:
-    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
-
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -1207,6 +1303,9 @@ packages:
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -1639,6 +1738,16 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
+    hasBin: true
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -1838,10 +1947,6 @@ packages:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
 
-  is-buffer@2.0.5:
-    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
-    engines: {node: '>=4'}
-
   is-bun-module@2.0.0:
     resolution: {integrity: sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==}
 
@@ -1884,9 +1989,6 @@ packages:
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
-
-  is-node-process@1.2.0:
-    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
@@ -2161,6 +2263,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -2198,6 +2304,9 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -2354,6 +2463,15 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  resend@6.12.3:
+    resolution: {integrity: sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2375,10 +2493,6 @@ packages:
     resolution: {integrity: sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==}
     engines: {node: '>= 0.4'}
     hasBin: true
-
-  retry@0.13.1:
-    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
-    engines: {node: '>= 4'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -2478,6 +2592,9 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
@@ -2517,6 +2634,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -2547,6 +2667,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svix@1.92.2:
+    resolution: {integrity: sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==}
+
   tailwindcss@3.4.17:
     resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
     engines: {node: '>=14.0.0'}
@@ -2564,10 +2687,6 @@ packages:
 
   third-party-capital@1.0.20:
     resolution: {integrity: sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==}
-
-  throttleit@2.1.0:
-    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
-    engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
@@ -2633,10 +2752,6 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@6.24.0:
-    resolution: {integrity: sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==}
-    engines: {node: '>=18.17'}
-
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
@@ -2678,6 +2793,10 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   yaml@2.8.1:
     resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
     engines: {node: '>= 14.6'}
@@ -2693,6 +2812,271 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      tslib: 2.8.1
+
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1053.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/credential-provider-node': 3.972.44
+      '@aws-sdk/middleware-bucket-endpoint': 3.972.15
+      '@aws-sdk/middleware-expect-continue': 3.972.13
+      '@aws-sdk/middleware-flexible-checksums': 3.974.21
+      '@aws-sdk/middleware-location-constraint': 3.972.11
+      '@aws-sdk/middleware-sdk-s3': 3.972.42
+      '@aws-sdk/middleware-ssec': 3.972.11
+      '@aws-sdk/signature-v4-multi-region': 3.996.28
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.13':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/xml-builder': 3.972.25
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.4
+      '@smithy/signature-v4': 5.4.4
+      '@smithy/types': 4.14.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/crc64-nvme@3.972.9':
+    dependencies:
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.39':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/credential-provider-env': 3.972.39
+      '@aws-sdk/credential-provider-http': 3.972.41
+      '@aws-sdk/credential-provider-login': 3.972.43
+      '@aws-sdk/credential-provider-process': 3.972.39
+      '@aws-sdk/credential-provider-sso': 3.972.43
+      '@aws-sdk/credential-provider-web-identity': 3.972.43
+      '@aws-sdk/nested-clients': 3.997.11
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/credential-provider-imds': 4.3.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/nested-clients': 3.997.11
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.44':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.39
+      '@aws-sdk/credential-provider-http': 3.972.41
+      '@aws-sdk/credential-provider-ini': 3.972.43
+      '@aws-sdk/credential-provider-process': 3.972.39
+      '@aws-sdk/credential-provider-sso': 3.972.43
+      '@aws-sdk/credential-provider-web-identity': 3.972.43
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/credential-provider-imds': 4.3.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.39':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/nested-clients': 3.997.11
+      '@aws-sdk/token-providers': 3.1052.0
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/nested-clients': 3.997.11
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.15':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-expect-continue@3.972.13':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.21':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/crc64-nvme': 3.972.9
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-location-constraint@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.28
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/signature-v4': 5.4.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-ssec@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.11':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.28
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.28':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/signature-v4': 5.4.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1052.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/nested-clients': 3.997.11
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.9':
+    dependencies:
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.25':
+    dependencies:
+      '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.2
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@datadog/browser-core@6.31.0': {}
 
@@ -3089,6 +3473,8 @@ snapshots:
       react: 18.3.1
       third-party-capital: 1.0.20
 
+  '@nodable/entities@2.1.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3106,6 +3492,56 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.16.1': {}
+
+  '@smithy/core@3.24.4':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.7.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.4.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@stablelib/base64@1.0.1': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -3336,24 +3772,6 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@2.0.1(next@15.5.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
-    optionalDependencies:
-      next: 15.5.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-
-  '@vercel/blob@2.3.1':
-    dependencies:
-      async-retry: 1.3.3
-      is-buffer: 2.0.5
-      is-node-process: 1.2.0
-      throttleit: 2.1.0
-      undici: 6.24.0
-
-  '@vercel/speed-insights@2.0.0(next@15.5.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
-    optionalDependencies:
-      next: 15.5.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -3457,10 +3875,6 @@ snapshots:
 
   async-function@1.0.0: {}
 
-  async-retry@1.3.3:
-    dependencies:
-      retry: 0.13.1
-
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -3474,6 +3888,8 @@ snapshots:
   balanced-match@4.0.4: {}
 
   binary-extensions@2.3.0: {}
+
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.12:
     dependencies:
@@ -4021,6 +4437,20 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
+
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
@@ -4228,8 +4658,6 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
-  is-buffer@2.0.5: {}
-
   is-bun-module@2.0.0:
     dependencies:
       semver: 7.7.4
@@ -4272,8 +4700,6 @@ snapshots:
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
-
-  is-node-process@1.2.0: {}
 
   is-number-object@1.1.1:
     dependencies:
@@ -4546,6 +4972,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
@@ -4568,6 +4996,8 @@ snapshots:
   pirates@4.0.7: {}
 
   possible-typed-array-names@1.1.0: {}
+
+  postal-mime@2.7.4: {}
 
   postcss-import@15.1.0(postcss@8.5.8):
     dependencies:
@@ -4676,6 +5106,11 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  resend@6.12.3:
+    dependencies:
+      postal-mime: 2.7.4
+      svix: 1.92.2
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -4700,8 +5135,6 @@ snapshots:
       object-keys: 1.1.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-
-  retry@0.13.1: {}
 
   reusify@1.1.0: {}
 
@@ -4842,6 +5275,11 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -4905,6 +5343,8 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strnum@2.3.0: {}
+
   styled-jsx@5.1.6(react@18.3.1):
     dependencies:
       client-only: 0.0.1
@@ -4929,6 +5369,10 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svix@1.92.2:
+    dependencies:
+      standardwebhooks: 1.0.0
 
   tailwindcss@3.4.17:
     dependencies:
@@ -4968,8 +5412,6 @@ snapshots:
       any-promise: 1.3.0
 
   third-party-capital@1.0.20: {}
-
-  throttleit@2.1.0: {}
 
   tinyglobby@0.2.15:
     dependencies:
@@ -5052,8 +5494,6 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@6.24.0: {}
-
   unrs-resolver@1.11.1:
     dependencies:
       napi-postinstall: 0.3.4
@@ -5134,6 +5574,8 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wrappy@1.0.2: {}
+
+  xml-naming@0.1.0: {}
 
   yaml@2.8.1: {}
 

--- a/scripts/generate-gallery-variants.ts
+++ b/scripts/generate-gallery-variants.ts
@@ -1,5 +1,8 @@
 import { spawn } from "node:child_process";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
 import type { S3Client as S3ClientType } from "@aws-sdk/client-s3";
+import type { GalleryImage } from "../src/app/_data/galleryTypes";
 import sharp from "sharp";
 import { galleryPreparedRecords } from "../src/app/_data/galleryPreparedRecords";
 import { gallerySections } from "../src/app/_data/gallerySections";
@@ -179,9 +182,52 @@ const uploadWithWrangler = async (
   });
 };
 
+const collectReferencedImagePaths = async (dir: string): Promise<string[]> => {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const nested = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) return collectReferencedImagePaths(entryPath);
+      if (!/\.(tsx?|jsx?)$/.test(entry.name)) return [];
+
+      const content = await readFile(entryPath, "utf8");
+      return Array.from(
+        content.matchAll(
+          /["'](\/images\/(?:gallery|client_experiences|wildlife)\/[^"']+)["']/g,
+        ),
+      ).flatMap((match) => {
+        const value = match[1];
+        if (
+          !value ||
+          value.includes("/gallery-variants/") ||
+          value.includes("/variants/")
+        ) {
+          return [];
+        }
+
+        return [value];
+      });
+    }),
+  );
+
+  return nested.flat();
+};
+
+const referencedImagePaths = await collectReferencedImagePaths(
+  path.join(process.cwd(), "src/app"),
+);
+const referencedImages: GalleryImage[] = referencedImagePaths.map((src) => ({
+  src,
+  alt: path.basename(src, path.extname(src)).replace(/[-_]/g, " "),
+  width: 0,
+  height: 0,
+  blurDataURL: "",
+}));
+
 const allOriginals = [
   ...gallerySections.flatMap((section) => section.images),
   ...Object.values(galleryPreparedRecords).flat(),
+  ...referencedImages,
 ];
 const originals = Array.from(
   new Map(allOriginals.map((image) => [image.src, image])).values(),

--- a/scripts/generate-gallery-variants.ts
+++ b/scripts/generate-gallery-variants.ts
@@ -1,7 +1,8 @@
+import { spawn } from "node:child_process";
+import type { S3Client as S3ClientType } from "@aws-sdk/client-s3";
 import sharp from "sharp";
-import { head, put } from "@vercel/blob";
+import { galleryPreparedRecords } from "../src/app/_data/galleryPreparedRecords";
 import { gallerySections } from "../src/app/_data/gallerySections";
-import { withGalleryBaseUrl } from "../src/app/_utils/galleryImages";
 import {
   GALLERY_LIGHTBOX_QUALITY,
   GALLERY_LIGHTBOX_WIDTH,
@@ -10,86 +11,258 @@ import {
   getGalleryVariantPath,
 } from "../src/app/_utils/galleryImageVariants";
 
+const uploadMode = process.env.R2_UPLOAD_MODE === "wrangler" ? "wrangler" : "s3";
+
+const requiredEnvVars =
+  uploadMode === "s3"
+    ? ([
+        "R2_ACCOUNT_ID",
+        "R2_ACCESS_KEY_ID",
+        "R2_SECRET_ACCESS_KEY",
+        "R2_BUCKET",
+      ] as const)
+    : (["R2_BUCKET"] as const);
+
+for (const key of requiredEnvVars) {
+  if (!process.env[key]) {
+    throw new Error(`${key} is required`);
+  }
+}
+
 const force = process.argv.includes("--force");
-const concurrency = Number(process.env.GALLERY_VARIANT_CONCURRENCY ?? "6");
+const includeOriginals = !process.argv.includes("--variants-only");
+const concurrency = Number(
+  process.env.GALLERY_VARIANT_CONCURRENCY ??
+    (uploadMode === "wrangler" ? "2" : "6"),
+);
 const limit = Number(process.env.GALLERY_VARIANT_LIMIT ?? "0");
 const match = process.env.GALLERY_VARIANT_MATCH ?? "";
-const cacheControlMaxAge = 60 * 60 * 24 * 365;
+const sourceBaseUrl = (
+  process.env.GALLERY_SOURCE_BASE_URL ??
+  process.env.NEXT_PUBLIC_GALLERY_BASE_URL ??
+  ""
+).replace(/\/$/, "");
 
-const originals = gallerySections.flatMap((section) => section.images);
+const bucket = process.env.R2_BUCKET!;
+const cacheControl = "public, max-age=31536000, immutable";
 
-const allVariants = originals.flatMap((image) => [
-  {
-    kind: "thumb",
-    originalPath: image.src,
-    originalUrl: withGalleryBaseUrl(image.src),
-    variantPath: getGalleryVariantPath(image.src, "thumb"),
-    width: GALLERY_THUMB_WIDTH,
-    quality: GALLERY_THUMB_QUALITY,
-  },
-  {
-    kind: "lightbox",
-    originalPath: image.src,
-    originalUrl: withGalleryBaseUrl(image.src),
-    variantPath: getGalleryVariantPath(image.src, "lightbox"),
-    width: GALLERY_LIGHTBOX_WIDTH,
-    quality: GALLERY_LIGHTBOX_QUALITY,
-  },
-]).filter((item) => item.variantPath);
+let s3ClientPromise: Promise<S3ClientType> | undefined;
 
-const matchedVariants = match
-  ? allVariants.filter((variant) => variant.originalPath.includes(match))
-  : allVariants;
-const variants = limit > 0 ? matchedVariants.slice(0, limit) : matchedVariants;
+const getS3Client = async () => {
+  s3ClientPromise ??= import("@aws-sdk/client-s3").then(({ S3Client }) => {
+    return new S3Client({
+      region: "auto",
+      endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+      credentials: {
+        accessKeyId: process.env.R2_ACCESS_KEY_ID!,
+        secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,
+        sessionToken: process.env.R2_SESSION_TOKEN,
+      },
+    });
+  });
 
-const processVariant = async (variant: typeof variants[number]) => {
-  if (!variant.variantPath) {
-    return { status: "skipped" as const, variant };
+  return s3ClientPromise;
+};
+
+const withSourceBaseUrl = (path: string) =>
+  path.startsWith("http://") || path.startsWith("https://")
+    ? path
+    : `${sourceBaseUrl}${path}`;
+
+const getObjectKey = (path: string) => path.replace(/^\//, "");
+
+const getContentType = (path: string) => {
+  const lower = path.toLowerCase();
+  if (lower.endsWith(".webp")) return "image/webp";
+  if (lower.endsWith(".png")) return "image/png";
+  if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg";
+  if (lower.endsWith(".mp4")) return "video/mp4";
+  return "application/octet-stream";
+};
+
+const objectExists = async (key: string) => {
+  if (uploadMode === "wrangler") {
+    return false;
   }
 
-  if (!force) {
-    try {
-      await head(variant.variantPath);
-      return { status: "exists" as const, variant };
-    } catch {
-      // Upload below.
-    }
+  try {
+    const { HeadObjectCommand } = await import("@aws-sdk/client-s3");
+    const client = await getS3Client();
+    await client.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const fetchOriginal = async (path: string) => {
+  if (!sourceBaseUrl && !path.startsWith("http")) {
+    throw new Error(
+      "GALLERY_SOURCE_BASE_URL or NEXT_PUBLIC_GALLERY_BASE_URL is required to fetch gallery originals",
+    );
   }
 
-  const response = await fetch(variant.originalUrl, {
+  const response = await fetch(withSourceBaseUrl(path), {
     headers: { "cache-control": "no-cache" },
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch ${variant.originalUrl}: ${response.status}`);
+    throw new Error(`Failed to fetch ${path}: ${response.status}`);
   }
 
-  const inputBuffer = Buffer.from(await response.arrayBuffer());
-  const outputBuffer = await sharp(inputBuffer)
-    .rotate()
-    .resize({
-      width: variant.width,
-      withoutEnlargement: true,
-      fit: "inside",
-    })
-    .webp({
-      quality: variant.quality,
-      effort: 6,
-    })
-    .toBuffer();
-
-  await put(variant.variantPath, outputBuffer, {
-    access: "public",
-    addRandomSuffix: false,
-    allowOverwrite: true,
-    cacheControlMaxAge,
-    contentType: "image/webp",
-  });
-
-  return { status: "uploaded" as const, variant, bytes: outputBuffer.length };
+  return Buffer.from(await response.arrayBuffer());
 };
 
-const queue = [...variants];
+const uploadObject = async (path: string, body: Buffer, contentType: string) => {
+  if (uploadMode === "wrangler") {
+    await uploadWithWrangler(path, body, contentType);
+    return;
+  }
+
+  const { PutObjectCommand } = await import("@aws-sdk/client-s3");
+  const client = await getS3Client();
+  await client.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: getObjectKey(path),
+      Body: body,
+      ContentType: contentType,
+      CacheControl: cacheControl,
+    }),
+  );
+};
+
+const uploadWithWrangler = async (
+  path: string,
+  body: Buffer,
+  contentType: string,
+) => {
+  const key = getObjectKey(path);
+  const args = [
+    "wrangler",
+    "r2",
+    "object",
+    "put",
+    `${bucket}/${key}`,
+    "--remote",
+    "--pipe",
+    "--content-type",
+    contentType,
+    "--cache-control",
+    cacheControl,
+    "--force",
+  ];
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn("npx", args, {
+      stdio: ["pipe", "ignore", "pipe"],
+    });
+    let stderr = "";
+
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      reject(
+        new Error(
+          `wrangler upload failed for ${path} with exit code ${code}: ${stderr}`,
+        ),
+      );
+    });
+    child.stdin.end(body);
+  });
+};
+
+const allOriginals = [
+  ...gallerySections.flatMap((section) => section.images),
+  ...Object.values(galleryPreparedRecords).flat(),
+];
+const originals = Array.from(
+  new Map(allOriginals.map((image) => [image.src, image])).values(),
+);
+const matchedOriginals = match
+  ? originals.filter((image) => image.src.includes(match))
+  : originals;
+const selectedOriginals = limit > 0 ? matchedOriginals.slice(0, limit) : matchedOriginals;
+
+const workItems = selectedOriginals.flatMap((image) => {
+  const variants = [
+    {
+      kind: "thumb" as const,
+      originalPath: image.src,
+      outputPath: getGalleryVariantPath(image.src, "thumb"),
+      width: GALLERY_THUMB_WIDTH,
+      quality: GALLERY_THUMB_QUALITY,
+    },
+    {
+      kind: "lightbox" as const,
+      originalPath: image.src,
+      outputPath: getGalleryVariantPath(image.src, "lightbox"),
+      width: GALLERY_LIGHTBOX_WIDTH,
+      quality: GALLERY_LIGHTBOX_QUALITY,
+    },
+  ].filter((item) => item.outputPath);
+
+  return includeOriginals
+    ? [
+        {
+          kind: "original" as const,
+          originalPath: image.src,
+          outputPath: image.src,
+        },
+        ...variants,
+      ]
+    : variants;
+});
+
+const sourceCache = new Map<string, Promise<Buffer>>();
+
+const getOriginalBuffer = (path: string) => {
+  const cached = sourceCache.get(path);
+  if (cached) return cached;
+  const promise = fetchOriginal(path);
+  sourceCache.set(path, promise);
+  return promise;
+};
+
+const processItem = async (item: typeof workItems[number]) => {
+  if (!item.outputPath) {
+    return { status: "skipped" as const, item };
+  }
+
+  const key = getObjectKey(item.outputPath);
+  if (!force && await objectExists(key)) {
+    return { status: "exists" as const, item };
+  }
+
+  const inputBuffer = await getOriginalBuffer(item.originalPath);
+  const outputBuffer = item.kind === "original"
+    ? inputBuffer
+    : await sharp(inputBuffer)
+      .rotate()
+      .resize({
+        width: item.width,
+        withoutEnlargement: true,
+        fit: "inside",
+      })
+      .webp({
+        quality: item.quality,
+        effort: 6,
+      })
+      .toBuffer();
+
+  await uploadObject(item.outputPath, outputBuffer, getContentType(item.outputPath));
+
+  return { status: "uploaded" as const, item, bytes: outputBuffer.length };
+};
+
+const queue = [...workItems];
 let uploaded = 0;
 let exists = 0;
 let skipped = 0;
@@ -99,13 +272,13 @@ const worker = async () => {
     const next = queue.shift();
     if (!next) return;
 
-    const result = await processVariant(next);
+    const result = await processItem(next);
     if (result.status === "uploaded") {
       uploaded += 1;
-      console.log(`uploaded ${next.kind} ${next.variantPath} (${result.bytes} bytes)`);
+      console.log(`uploaded ${next.kind} ${next.outputPath} (${result.bytes} bytes)`);
     } else if (result.status === "exists") {
       exists += 1;
-      console.log(`exists ${next.kind} ${next.variantPath}`);
+      console.log(`exists ${next.kind} ${next.outputPath}`);
     } else {
       skipped += 1;
       console.log(`skipped ${next.kind} ${next.originalPath}`);
@@ -119,13 +292,16 @@ await Promise.all(
 
 console.log(
   JSON.stringify({
-    total: variants.length,
+    total: workItems.length,
     uploaded,
     exists,
     skipped,
     force,
+    includeOriginals,
     concurrency,
     limit,
     match,
+    bucket,
+    uploadMode,
   }, null, 2),
 );

--- a/src/app/_components/sections/AboutUsBannerSection.tsx
+++ b/src/app/_components/sections/AboutUsBannerSection.tsx
@@ -2,10 +2,14 @@ import React from "react";
 import Image from "next/image";
 import { dynamicBlurDataUrl } from "~/app/_utils/ImageUtils";
 import { withGalleryBaseUrl } from "~/app/_utils/galleryImages";
+import { getGalleryVariantPath } from "~/app/_utils/galleryImageVariants";
 
 export const AboutUsBannerSection = async () => {
     const imageSrc = withGalleryBaseUrl(
-        "/images/gallery/lodge/lobby/lebambou-lobby-001.webp",
+        getGalleryVariantPath(
+            "/images/gallery/lodge/lobby/lebambou-lobby-001.webp",
+            "lightbox",
+        ) ?? "/images/gallery/lodge/lobby/lebambou-lobby-001.webp",
     );
 
     return (
@@ -17,6 +21,7 @@ export const AboutUsBannerSection = async () => {
                 className="opacity-50 object-cover"
                 quality={90}
                 priority={true}
+                unoptimized
                 blurDataURL={await dynamicBlurDataUrl(
                     imageSrc,
                 )}

--- a/src/app/_components/sections/AttractionsUsBannerSection.tsx
+++ b/src/app/_components/sections/AttractionsUsBannerSection.tsx
@@ -2,10 +2,14 @@ import Image from "next/image";
 import React from "react";
 import { dynamicBlurDataUrl } from "~/app/_utils/ImageUtils";
 import { withGalleryBaseUrl } from "~/app/_utils/galleryImages";
+import { getGalleryVariantPath } from "~/app/_utils/galleryImageVariants";
 
 export const AttractionsUsBannerSection = async () => {
   const imageSrc = withGalleryBaseUrl(
-    "/images/gallery/attractions/ellen-campus/ellendegenerescampus-001.webp",
+    getGalleryVariantPath(
+      "/images/gallery/attractions/ellen-campus/ellendegenerescampus-001.webp",
+      "lightbox",
+    ) ?? "/images/gallery/attractions/ellen-campus/ellendegenerescampus-001.webp",
   );
 
   return (
@@ -17,6 +21,7 @@ export const AttractionsUsBannerSection = async () => {
         className="opacity-70 object-cover"
         quality={75}
         priority={true}
+        unoptimized
         blurDataURL={await dynamicBlurDataUrl(
           imageSrc,
         )}

--- a/src/app/_components/sections/CommunitySection.tsx
+++ b/src/app/_components/sections/CommunitySection.tsx
@@ -2,16 +2,26 @@ import Image from "next/image";
 import React from "react";
 import { dynamicBlurDataUrl } from "~/app/_utils/ImageUtils";
 import { withGalleryBaseUrl } from "~/app/_utils/galleryImages";
+import { getGalleryVariantPath } from "~/app/_utils/galleryImageVariants";
 
 export const CommunitySection = async () => {
   const culturalImage = withGalleryBaseUrl(
-    "/images/gallery/attractions/gorilla-guardians/cultural/gorillaguardiansvillage-culturalperformance-001.webp",
+    getGalleryVariantPath(
+      "/images/gallery/attractions/gorilla-guardians/cultural/gorillaguardiansvillage-culturalperformance-001.webp",
+      "thumb",
+    ) ?? "/images/gallery/attractions/gorilla-guardians/cultural/gorillaguardiansvillage-culturalperformance-001.webp",
   );
   const danceImage = withGalleryBaseUrl(
-    "/images/gallery/attractions/gorilla-guardians/cultural/gorillaguardiansvillage-culturalperformance-002.webp",
+    getGalleryVariantPath(
+      "/images/gallery/attractions/gorilla-guardians/cultural/gorillaguardiansvillage-culturalperformance-002.webp",
+      "thumb",
+    ) ?? "/images/gallery/attractions/gorilla-guardians/cultural/gorillaguardiansvillage-culturalperformance-002.webp",
   );
   const drummingImage = withGalleryBaseUrl(
-    "/images/gallery/attractions/gorilla-guardians/drumming/gorillaguardiansvillage-drumming-001.webp",
+    getGalleryVariantPath(
+      "/images/gallery/attractions/gorilla-guardians/drumming/gorillaguardiansvillage-drumming-001.webp",
+      "thumb",
+    ) ?? "/images/gallery/attractions/gorilla-guardians/drumming/gorillaguardiansvillage-drumming-001.webp",
   );
 
   return (
@@ -40,6 +50,7 @@ export const CommunitySection = async () => {
                   alt="Gorilla Guardians cultural performance"
                   width={2600}
                   height={1950}
+                  unoptimized
                   className="community-image object-cover w-full h-full"
                   blurDataURL={await dynamicBlurDataUrl(
                     culturalImage,
@@ -64,6 +75,7 @@ export const CommunitySection = async () => {
                   alt="Gorilla Guardians dance performance"
                   width={2600}
                   height={1950}
+                  unoptimized
                   className="object-cover w-full h-full"
                   blurDataURL={await dynamicBlurDataUrl(
                     danceImage,
@@ -88,6 +100,7 @@ export const CommunitySection = async () => {
                   alt="Gorilla Guardians drumming performance"
                   width={1950}
                   height={2600}
+                  unoptimized
                   className="object-cover w-full h-full"
                   blurDataURL={await dynamicBlurDataUrl(
                     drummingImage,

--- a/src/app/_components/sections/DiscoverRoomsSection.tsx
+++ b/src/app/_components/sections/DiscoverRoomsSection.tsx
@@ -2,10 +2,14 @@ import React from "react";
 import Image from "next/image";
 import { dynamicBlurDataUrl } from "~/app/_utils/ImageUtils";
 import { withGalleryBaseUrl } from "~/app/_utils/galleryImages";
+import { getGalleryVariantPath } from "~/app/_utils/galleryImageVariants";
 
 export const DiscoverRoomsSection = async () => {
   const imageSrc = withGalleryBaseUrl(
-    "/images/gallery/rooms/single/lebambou-singleroom-001.webp",
+    getGalleryVariantPath(
+      "/images/gallery/rooms/single/lebambou-singleroom-001.webp",
+      "lightbox",
+    ) ?? "/images/gallery/rooms/single/lebambou-singleroom-001.webp",
   );
 
   return (
@@ -16,6 +20,7 @@ export const DiscoverRoomsSection = async () => {
         fill={true}
         className="opacity-70 object-cover object-[50%_78%]"
         loading="lazy"
+        unoptimized
         blurDataURL={await dynamicBlurDataUrl(imageSrc)}
         placeholder="blur"
       />

--- a/src/app/_components/sections/FamilyCottageFeatureSection.tsx
+++ b/src/app/_components/sections/FamilyCottageFeatureSection.tsx
@@ -34,6 +34,7 @@ export const FamilyCottageFeatureSection = () => {
                   className="object-cover object-[42%_center] transition duration-700 hover:scale-[1.02]"
                   sizes="(max-width: 1024px) 100vw, 45vw"
                   priority={false}
+                  unoptimized
                 />
               </div>
               <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-1">
@@ -53,6 +54,7 @@ export const FamilyCottageFeatureSection = () => {
                         fill
                         className="object-cover transition duration-700 hover:scale-[1.02]"
                         sizes="(max-width: 1024px) 45vw, 220px"
+                        unoptimized
                       />
                     </div>
                   );

--- a/src/app/_components/sections/HistoryVisionValuesSection.tsx
+++ b/src/app/_components/sections/HistoryVisionValuesSection.tsx
@@ -2,10 +2,14 @@ import Image from "next/image";
 import React from "react";
 import { dynamicBlurDataUrl } from "~/app/_utils/ImageUtils";
 import { withGalleryBaseUrl } from "~/app/_utils/galleryImages";
+import { getGalleryVariantPath } from "~/app/_utils/galleryImageVariants";
 
 export const HistoryVisionValuesSection = async () => {
     const aboutImageSrc = withGalleryBaseUrl(
-        "/images/gallery/lodge/lobby/lebambou-lobby-008.webp",
+        getGalleryVariantPath(
+            "/images/gallery/lodge/lobby/lebambou-lobby-008.webp",
+            "thumb",
+        ) ?? "/images/gallery/lodge/lobby/lebambou-lobby-008.webp",
     );
 
     return (
@@ -31,6 +35,7 @@ export const HistoryVisionValuesSection = async () => {
                             className="rounded-lg w-full h-[27rem] object-cover object-center md:h-auto"
                             width={1950}
                             height={2600}
+                            unoptimized
                             blurDataURL={await dynamicBlurDataUrl(
                                 aboutImageSrc,
                             )}

--- a/src/app/_components/sections/StayBannerSection.tsx
+++ b/src/app/_components/sections/StayBannerSection.tsx
@@ -1,10 +1,14 @@
 import React from "react";
 import Image from "next/image";
 import { withGalleryBaseUrl } from "~/app/_utils/galleryImages";
+import { getGalleryVariantPath } from "~/app/_utils/galleryImageVariants";
 
 export const StayBannerSection = () => {
   const imageSrc = withGalleryBaseUrl(
-    "/images/gallery/rooms/twin/lebambou-twinroom-001.webp",
+    getGalleryVariantPath(
+      "/images/gallery/rooms/twin/lebambou-twinroom-001.webp",
+      "lightbox",
+    ) ?? "/images/gallery/rooms/twin/lebambou-twinroom-001.webp",
   );
 
   return (
@@ -16,6 +20,7 @@ export const StayBannerSection = () => {
         className="object-cover opacity-70"
         quality={75}
         priority={true}
+        unoptimized
       />
       <div className="relative mx-auto w-full max-w-[calc(100vw-2rem)] px-2 pb-16 sm:max-w-[calc(100vw-4rem)] sm:px-0 sm:pb-20">
         <div className="mx-auto max-w-[720px] rounded-[22px] bg-[rgba(121,98,90,0.78)] px-6 pb-6 pt-3 text-center backdrop-blur-[3px] sm:px-10 sm:pb-8 sm:pt-4">

--- a/src/app/_utils/ImageUtils.ts
+++ b/src/app/_utils/ImageUtils.ts
@@ -1,44 +1,10 @@
-const baseUrl = (() => {
-  if (typeof window === "undefined") {
-    // Server-side
-    return process.env.NODE_ENV === "development"
-      ? "http://localhost:3000"
-      : process.env.NEXT_PUBLIC_SITE_URL ?? "https://lebambougorillalodge.com";
-  } else {
-    // Client-side
-    return window.location.origin;
-  }
-})();
+const STATIC_BLUR_DATA_URL =
+  "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0nMTYnIGhlaWdodD0nMTAnIHZpZXdCb3g9JzAgMCAxNiAxMCcgeG1sbnM9J2h0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnJyBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSdub25lJz48cmVjdCB3aWR0aD0nMTYnIGhlaWdodD0nMTAnIGZpbGw9JyNiOWM1YzQnLz48cGF0aCBkPSdNMCwxMCBMMTYsMCBMMTYsMTAgWicgZmlsbD0nI2Q3ZGZkZScgZmlsbC1vcGFjaXR5PScwLjQ1Jy8+PC9zdmc+";
 
 export async function dynamicBlurDataUrl(url: string) {
-  // Support absolute URLs (e.g., Vercel Blob) and local paths
-  const isAbsolute = /^https?:\/\//.test(url);
-  const pathOnly = isAbsolute ? url : `/${url.startsWith("/") ? url.slice(1) : url}`;
-  const optimizerUrl = `${baseUrl}/_next/image?url=${encodeURIComponent(pathOnly)}&w=16&q=50`;
+  void url;
 
-  // Try fetching a tiny optimized image via Next's optimizer (small, cacheable under 2MB)
-  try {
-    const res = await fetch(
-      optimizerUrl,
-      typeof window === "undefined" ? { next: { revalidate: 86400 } } : undefined,
-    );
-    if (res.ok) {
-      const buffer = await res.arrayBuffer();
-      const base64 = Buffer.from(new Uint8Array(buffer)).toString("base64");
-      return `data:image/webp;base64,${base64}`;
-    }
-  } catch {
-    // ignore and fall back
-  }
-
-  // Fallback: fetch original with no-store (avoids Next data cache) and inline it
-  const res = await fetch(isAbsolute ? url : `${baseUrl}/${url.startsWith("/") ? url.slice(1) : url}`,
-    { cache: "no-store" },
-  );
-  const buffer = await res.arrayBuffer();
-  const lower = url.toLowerCase();
-  const mime = lower.endsWith(".png") ? "image/png" : lower.endsWith(".webp") ? "image/webp" : "image/jpeg";
-  return `data:${mime};base64,${Buffer.from(new Uint8Array(buffer)).toString("base64")}`;
+  return STATIC_BLUR_DATA_URL;
 }
 
 // import imagemin from "imagemin";

--- a/src/app/_utils/ImageUtils.ts
+++ b/src/app/_utils/ImageUtils.ts
@@ -3,9 +3,7 @@ const baseUrl = (() => {
     // Server-side
     return process.env.NODE_ENV === "development"
       ? "http://localhost:3000"
-      : process.env.VERCEL_URL
-        ? `https://${process.env.VERCEL_URL}`
-        : "https://lebambougorillalodge.com";
+      : process.env.NEXT_PUBLIC_SITE_URL ?? "https://lebambougorillalodge.com";
   } else {
     // Client-side
     return window.location.origin;

--- a/src/app/family-cottage/page.tsx
+++ b/src/app/family-cottage/page.tsx
@@ -71,6 +71,7 @@ export default function FamilyCottagePage() {
             priority
             className="object-cover opacity-70"
             sizes="100vw"
+            unoptimized
           />
           <div className="relative mx-auto flex min-h-[calc(100dvh-7rem)] max-w-6xl items-end px-4 py-10 sm:px-6 lg:px-8 lg:py-16">
             <div className="max-w-3xl rounded-lg bg-[rgba(121,98,90,0.9)] px-5 py-6 text-[#ebf8f7] sm:px-8 sm:py-8">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,8 +5,6 @@ import "~/styles/normalize.css";
 import { type Metadata } from "next";
 import { Varela_Round } from "next/font/google";
 import { TRPCReactProvider } from "~/trpc/react";
-import { Analytics } from "@vercel/analytics/next";
-import { SpeedInsights } from "@vercel/speed-insights/next";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import Script from "next/script";
 import { FloatingWhatsAppButton } from "~/app/_components/FloatingWhatsAppButton";
@@ -134,8 +132,6 @@ export default function RootLayout({
             }}
           />
         </TRPCReactProvider>
-        <Analytics />
-        <SpeedInsights />
       </body>
     </html>
   );

--- a/src/env.js
+++ b/src/env.js
@@ -12,7 +12,9 @@ export const env = createEnv({
       .enum(["development", "test", "production"])
       .default("development"),
     EMAIL_PASSWORD_DEV: z.string().optional(),
-    EMAIL_PASSWORD_PROD: z.string(),
+    RESEND_API_KEY: z.string().optional(),
+    EMAIL_FROM: z.string().optional(),
+    EMAIL_TO: z.string().optional(),
   },
 
   /**
@@ -21,8 +23,10 @@ export const env = createEnv({
    * `NEXT_PUBLIC_`.
   */
   client: {
-    NEXT_PUBLIC_DD_CLIENT_APP_ID: z.string(),
-    NEXT_PUBLIC_DD_CLIENT_TOKEN: z.string(),
+    NEXT_PUBLIC_DD_CLIENT_APP_ID: z.string().optional(),
+    NEXT_PUBLIC_DD_CLIENT_TOKEN: z.string().optional(),
+    NEXT_PUBLIC_GALLERY_BASE_URL: z.string().url().optional(),
+    NEXT_PUBLIC_SITE_URL: z.string().url().optional(),
   },
 
   /**
@@ -34,9 +38,13 @@ export const env = createEnv({
     NODE_ENV: process.env.NODE_ENV,
     // NEXT_PUBLIC_CLIENTVAR: process.env.NEXT_PUBLIC_CLIENTVAR,
     EMAIL_PASSWORD_DEV: process.env.EMAIL_PASSWORD_DEV,
-    EMAIL_PASSWORD_PROD: process.env.EMAIL_PASSWORD_PROD,
+    RESEND_API_KEY: process.env.RESEND_API_KEY,
+    EMAIL_FROM: process.env.EMAIL_FROM,
+    EMAIL_TO: process.env.EMAIL_TO,
     NEXT_PUBLIC_DD_CLIENT_APP_ID: process.env.NEXT_PUBLIC_DD_CLIENT_APP_ID,
     NEXT_PUBLIC_DD_CLIENT_TOKEN: process.env.NEXT_PUBLIC_DD_CLIENT_TOKEN,
+    NEXT_PUBLIC_GALLERY_BASE_URL: process.env.NEXT_PUBLIC_GALLERY_BASE_URL,
+    NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially

--- a/src/server/api/routers/email.ts
+++ b/src/server/api/routers/email.ts
@@ -1,33 +1,9 @@
 import { z } from "zod";
 import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
-import nodemailer from "nodemailer";
-
-const isDevelopment = process.env.NODE_ENV === "development";
-const prodSenderAddress = "noreply@lebambougorillalodge.com";
-const prodInboxAddress = "info@lebambougorillalodge.com";
-const getSmtpPassword = (value: string | undefined) => value?.trim();
-
-const transporter = nodemailer.createTransport(
-    isDevelopment
-        ? {
-            host: "smtp.zoho.com",
-            port: 465,
-            secure: true,
-            auth: {
-                user: "kevin@deployitwith.me",
-                pass: process.env.EMAIL_PASSWORD_DEV,
-            },
-        }
-        : {
-            host: "smtp.purelymail.com",
-            port: 465,
-            secure: true,
-            auth: {
-                user: prodSenderAddress,
-                pass: getSmtpPassword(process.env.EMAIL_PASSWORD_PROD),
-            },
-        },
-);
+import {
+    lodgeInboxAddress,
+    sendLodgeEmail,
+} from "~/server/utils/emailDelivery";
 
 export const emailRouter = createTRPCRouter({
     sendContactEmail: publicProcedure
@@ -41,29 +17,20 @@ export const emailRouter = createTRPCRouter({
         .mutation(async ({ input }) => {
             const { name, email, message } = input;
 
-            const mailOptions = {
-                from: isDevelopment
-                    ? "kevin@deployitwith.me"
-                    : prodSenderAddress,
-                to: isDevelopment
-                    ? "kevin@deployitwith.me"
-                    : prodInboxAddress,
-                replyTo: isDevelopment
-                    ? "kevin@deployitwith.me"
-                    : prodInboxAddress,
-                subject: `New Contact Form Submission from ${name}`,
-                text: `Name: ${name}\nEmail: ${email}\nMessage: ${message}`,
-                html: `
+            try {
+                await sendLodgeEmail({
+                    to: lodgeInboxAddress,
+                    replyTo: lodgeInboxAddress,
+                    subject: `New Contact Form Submission from ${name}`,
+                    text: `Name: ${name}\nEmail: ${email}\nMessage: ${message}`,
+                    html: `
           <h2>New Contact Form Submission</h2>
           <p><strong>Name:</strong> ${name}</p>
           <p><strong>Email:</strong> ${email}</p>
           <p><strong>Message:</strong></p>
           <p>${message}</p>
         `,
-            };
-
-            try {
-                await transporter.sendMail(mailOptions);
+                });
                 return { success: true };
             } catch (error) {
                 console.error("Error sending email:", error);

--- a/src/server/utils/emailDelivery.ts
+++ b/src/server/utils/emailDelivery.ts
@@ -1,0 +1,66 @@
+import nodemailer from "nodemailer";
+import { Resend } from "resend";
+
+const isDevelopment = process.env.NODE_ENV === "development";
+const devSenderAddress = "kevin@deployitwith.me";
+const prodSenderAddress =
+  process.env.EMAIL_FROM ?? "Le Bambou Gorilla Lodge <noreply@lebambougorillalodge.com>";
+const prodInboxAddress = process.env.EMAIL_TO ?? "info@lebambougorillalodge.com";
+
+export const lodgeSenderAddress = isDevelopment ? devSenderAddress : prodSenderAddress;
+export const lodgeInboxAddress = isDevelopment ? devSenderAddress : prodInboxAddress;
+
+const smtpTransporter = isDevelopment
+  ? nodemailer.createTransport({
+      host: "smtp.zoho.com",
+      port: 465,
+      secure: true,
+      auth: {
+        user: devSenderAddress,
+        pass: process.env.EMAIL_PASSWORD_DEV,
+      },
+    })
+  : null;
+
+const resend = process.env.RESEND_API_KEY
+  ? new Resend(process.env.RESEND_API_KEY)
+  : null;
+
+interface SendLodgeEmailOptions {
+  to: string | string[];
+  replyTo?: string;
+  subject: string;
+  text?: string;
+  html: string;
+}
+
+export async function sendLodgeEmail(options: SendLodgeEmailOptions) {
+  if (smtpTransporter) {
+    await smtpTransporter.sendMail({
+      from: lodgeSenderAddress,
+      to: options.to,
+      replyTo: options.replyTo,
+      subject: options.subject,
+      text: options.text,
+      html: options.html,
+    });
+    return;
+  }
+
+  if (!resend) {
+    throw new Error("RESEND_API_KEY is required to send production email");
+  }
+
+  const { error } = await resend.emails.send({
+    from: lodgeSenderAddress,
+    to: Array.isArray(options.to) ? options.to : [options.to],
+    replyTo: options.replyTo,
+    subject: options.subject,
+    text: options.text,
+    html: options.html,
+  });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+}

--- a/src/server/utils/emailUtils.tsx
+++ b/src/server/utils/emailUtils.tsx
@@ -1,4 +1,3 @@
-import nodemailer from "nodemailer";
 import {
     additionalServices,
     roomPrices,
@@ -7,33 +6,10 @@ import {
 import { isEmail } from "validator";
 import dns from "dns";
 import { promisify } from "util";
-
-const isDevelopment = process.env.NODE_ENV === "development";
-const prodSenderAddress = "noreply@lebambougorillalodge.com";
-const prodInboxAddress = "info@lebambougorillalodge.com";
-const getSmtpPassword = (value: string | undefined) => value?.trim();
-
-const transporter = nodemailer.createTransport(
-    isDevelopment
-        ? {
-            host: "smtp.zoho.com",
-            port: 465,
-            secure: true,
-            auth: {
-                user: "kevin@deployitwith.me",
-                pass: process.env.EMAIL_PASSWORD_DEV,
-            },
-        }
-        : {
-            host: "smtp.purelymail.com",
-            port: 465,
-            secure: true,
-            auth: {
-                user: prodSenderAddress,
-                pass: getSmtpPassword(process.env.EMAIL_PASSWORD_PROD),
-            },
-        },
-);
+import {
+    lodgeInboxAddress,
+    sendLodgeEmail,
+} from "~/server/utils/emailDelivery";
 
 const resolveMx = promisify(dns.resolveMx);
 
@@ -125,13 +101,8 @@ export async function sendBookingConfirmationEmails(
     const grandTotal = roomTotal + servicesTotal;
 
     const guestMailOptions = {
-        from: isDevelopment
-            ? "kevin@deployitwith.me"
-            : prodSenderAddress,
         to: booking.guestEmail,
-        replyTo: isDevelopment
-            ? "kevin@deployitwith.me"
-            : prodInboxAddress,
+        replyTo: lodgeInboxAddress,
         subject: "Booking Confirmation - Le Bambou Gorilla Lodge",
         html: `
             <!DOCTYPE html>
@@ -290,16 +261,9 @@ export async function sendBookingConfirmationEmails(
     };
 
     const adminMailOptions = {
-        from: isDevelopment
-            ? "kevin@deployitwith.me"
-            : prodSenderAddress,
-        to: isDevelopment
-            ? "kevin@deployitwith.me"
-            : prodInboxAddress,
+        to: lodgeInboxAddress,
         subject: `New Booking - ${booking.guestName}`,
-        replyTo: isDevelopment
-            ? "kevin@deployitwith.me"
-            : prodInboxAddress,
+        replyTo: lodgeInboxAddress,
         html: `
             <h2>New Booking Received</h2>
             <p>A new booking has been made with the following details:</p>
@@ -357,6 +321,6 @@ export async function sendBookingConfirmationEmails(
         `,
     };
 
-    await transporter.sendMail(guestMailOptions);
-    await transporter.sendMail(adminMailOptions);
+    await sendLodgeEmail(guestMailOptions);
+    await sendLodgeEmail(adminMailOptions);
 }

--- a/src/trpc/react.tsx
+++ b/src/trpc/react.tsx
@@ -96,6 +96,6 @@ export function TRPCReactProvider(props: { children: React.ReactNode }) {
 
 function getBaseUrl() {
   if (typeof window !== "undefined") return window.location.origin;
-  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
+  if (process.env.NEXT_PUBLIC_SITE_URL) return process.env.NEXT_PUBLIC_SITE_URL;
   return `http://localhost:${process.env.PORT ?? 3000}`;
 }


### PR DESCRIPTION
## Summary
- add Fly deployment configuration and GitHub Actions publishing
- move gallery assets to Cloudflare R2 and use generated variants
- switch production transactional email to Resend
- tune Fly to one London machine for low-traffic lodge hosting

## Verification
- deployed and verified Fly app at https://le-bambou-next.fly.dev
- verified Resend domain and Fly RESEND_API_KEY secret
- route checks passed for /, /explore, /stay, /booking, /contact